### PR TITLE
DM-37517: use documenteer[guide]

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -9,7 +9,8 @@ Version History
 v1.2.2
 ------
 
-* Correct parsing of returned value from the image name service client
+* Correct parsing of returned value from the image name service client.
+* Simplify `ImageNameServiceClient` code and improve documentation.
 
 v1.2.1
 ------
@@ -23,7 +24,7 @@ v1.2.0
   Instead of a warning-level message that describes an error, issue a bland info-level message.
 * Run isort
 * Add isort and mypy to pre-commit and update other pre-commit software versions.
-* Add ImageNameServiceClient class
+* Add `ImageNameServiceClient` class
 
 v1.1.2
 ------

--- a/python/lsst/ts/utils/angle.py
+++ b/python/lsst/ts/utils/angle.py
@@ -33,7 +33,7 @@ import astropy.time
 import astropy.units as u
 import astropy.utils.iers
 
-AngleOrDegType = typing.Union[astropy.coordinates.Angle, float]
+AngleOrDegType: typing.TypeAlias = astropy.coordinates.Angle | float
 
 _MIDDLE_WRAP_ANGLE = astropy.coordinates.Angle(180, u.deg)
 _POSITIVE_WRAP_ANGLE = astropy.coordinates.Angle(360, u.deg)
@@ -46,9 +46,9 @@ def angle_diff(
 
     Parameters
     ----------
-    angle1 : `astropy.coordinates.Angle` or `float`
+    angle1
         Angle 1; if a float then in degrees
-    angle2 : `astropy.coordinates.Angle` or `float`
+    angle2
         Angle 2; if a float then in degrees
 
     Returns
@@ -67,7 +67,7 @@ def angle_wrap_center(angle: AngleOrDegType) -> astropy.coordinates.Angle:
 
     Parameters
     ----------
-    angle : `astropy.coordinates.Angle` or `float`
+    angle
         Angle; if a float then in degrees
 
     Returns
@@ -83,7 +83,7 @@ def angle_wrap_nonnegative(angle: AngleOrDegType) -> astropy.coordinates.Angle:
 
     Parameters
     ----------
-    angle : `astropy.coordinates.Angle` or `float`
+    angle
         Angle; if a float then in degrees
 
     Returns

--- a/python/lsst/ts/utils/image_name_service_client.py
+++ b/python/lsst/ts/utils/image_name_service_client.py
@@ -21,8 +21,6 @@
 
 __all__ = ["ImageNameServiceClient"]
 
-import io
-import json
 import logging
 
 import aiohttp
@@ -105,16 +103,7 @@ class ImageNameServiceClient:
             url, raise_for_status=True, connector=aiohttp.TCPConnector(ssl=False)
         ) as session:
             async with session.get(url=call_url, params=params) as response:
-                fd: io.StringIO = io.StringIO()
-                async for chunk in response.content.iter_chunked(1024):
-                    decoded_chunk = chunk.decode()
-                    self.log.info(f"{decoded_chunk=}")
-                    fd.write(decoded_chunk)
-                    self.log.info(f"{fd=}")
-                fd.seek(0)
-                values_json = fd.read()
-                self.log.debug(f"{values_json=}")
-                values: list[str] = json.loads(values_json)
+                values: list[str] = await response.json()
                 self.log.info(f"{values=}")
                 image_sequence_array = [int(item.split("_")[-1]) for item in values]
                 return image_sequence_array, values

--- a/python/lsst/ts/utils/misc.py
+++ b/python/lsst/ts/utils/misc.py
@@ -22,15 +22,15 @@
 __all__ = ["index_generator", "make_done_future"]
 
 import asyncio
-import typing
+from collections.abc import Generator
 
 # Maximum value of a 32-bit signed int
 MAX_INT32 = (1 << 31) - 1
 
 
 def index_generator(
-    imin: int = 1, imax: int = MAX_INT32, i0: typing.Optional[int] = None
-) -> typing.Generator[int, None, None]:
+    imin: int = 1, imax: int = MAX_INT32, i0: int | None = None
+) -> Generator[int, None, None]:
     """Sequential index generator.
 
     Returns values i0, i0+1, i0+2, ..., max, min, min+1, ...
@@ -65,7 +65,7 @@ def index_generator(
 
     # define an inner generator and return that
     # in order to get immediate argument checking
-    def index_impl() -> typing.Generator[int, None, None]:
+    def index_impl() -> Generator[int, None, None]:
         index = i0 - 1  # type: ignore
         while True:
             index += 1

--- a/python/lsst/ts/utils/tai.py
+++ b/python/lsst/ts/utils/tai.py
@@ -37,6 +37,7 @@ import math
 import threading
 import time
 import typing
+from collections.abc import Sequence
 
 import astropy.coordinates
 import astropy.time
@@ -52,16 +53,12 @@ MJD_MINUS_UNIX_SECONDS = (
 
 # A list of (utc_unix_seconds, TAI-UTC seconds);
 # automatically updated by `_update_leap_second_table`.
-_UTC_LEAP_SECOND_TABLE: typing.Optional[
-    typing.Sequence[typing.Tuple[float, float]]
-] = None
+_UTC_LEAP_SECOND_TABLE: Sequence[tuple[float, float]] | None = None
 # A list of (tai_unix_seconds, TAI-UTC seconds);
 # automatically updated by `_update_leap_second_table`.
-_TAI_LEAP_SECOND_TABLE: typing.Optional[
-    typing.Sequence[typing.Tuple[float, float]]
-] = None
+_TAI_LEAP_SECOND_TABLE: Sequence[tuple[float, float]] | None = None
 # A threading timer that schedules automatic update of the leap second table.
-_LEAP_SECOND_TABLE_UPDATE_TIMER: typing.Optional[threading.Timer] = None
+_LEAP_SECOND_TABLE_UPDATE_TIMER: threading.Timer | None = None
 # When to update the leap second table, in days before expiration.
 _LEAP_SECOND_TABLE_UPDATE_MARGIN_DAYS = 10
 
@@ -94,8 +91,8 @@ def current_tai_from_utc() -> float:
 
 
 def tai_from_utc(
-    utc: typing.Union[float, str, astropy.time.Time],
-    format: typing.Optional[str] = "unix",
+    utc: float | str | astropy.time.Time,
+    format: str | None = "unix",
 ) -> float:
     """Return TAI in unix seconds, given UTC or any `astropy.time.Time`.
 

--- a/python/lsst/ts/utils/testutils.py
+++ b/python/lsst/ts/utils/testutils.py
@@ -25,6 +25,7 @@ import contextlib
 import os
 import typing
 import unittest
+from collections.abc import Generator
 
 import astropy.coordinates
 import astropy.units as u
@@ -58,7 +59,7 @@ def assert_angles_almost_equal(
 
 
 @contextlib.contextmanager
-def modify_environ(**kwargs: typing.Any) -> typing.Generator[None, None, None]:
+def modify_environ(**kwargs: typing.Any) -> Generator[None, None, None]:
     """Context manager to temporarily patch os.environ.
 
     This calls `unittest.mock.patch` and is only intended for unit tests.
@@ -110,5 +111,5 @@ def modify_environ(**kwargs: typing.Any) -> typing.Generator[None, None, None]:
             new_environ.pop(name, None)
         else:
             new_environ[name] = value
-    with unittest.mock.patch("os.environ", new_environ):
+    with unittest.mock.patch("os.environ", new_environ):  # type: ignore
         yield

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -20,8 +20,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
-import typing
 import unittest
+from collections.abc import Generator, Sequence
 
 import pytest
 from lsst.ts import utils
@@ -30,8 +30,8 @@ from lsst.ts import utils
 class BasicsTestCase(unittest.IsolatedAsyncioTestCase):
     def check_index_generator(
         self,
-        generator: typing.Generator[int, None, None],
-        expected_values: typing.Sequence[int],
+        generator: Generator[int, None, None],
+        expected_values: Sequence[int],
     ) -> None:
         values = [next(generator) for i in range(len(expected_values))]
         assert values == list(expected_values)


### PR DESCRIPTION
This allows deleting type annotations from the Parameters section of doc strings; sphinx finally figures it out from type annotations.